### PR TITLE
Try switching to ruby/setup-ruby for CI setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup Ruby
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
 


### PR DESCRIPTION
Initial try at a fix for https://github.com/LOST-STATS/lost-stats.github.io/issues/192

From the [actions/setup-ruby page](https://github.com/actions/setup-ruby):
> Please note: This action is deprecated and should no longer be used. The team at GitHub has ceased making and accepting code contributions or maintaining issues tracker. Please, migrate your workflows to the [ruby/setup-ruby](https://github.com/ruby/setup-ruby), which is being actively maintained by the official Ruby organization.

cc @NickCH-K I saw your tweet - looks like a maintainer will need to approve me for the CI workflow to run so we can see if this works