### PR TITLE
Fix missing math mode

### DIFF
--- a/Machine_Learning/penalized_regression.md
+++ b/Machine_Learning/penalized_regression.md
@@ -82,7 +82,7 @@ Now we run lasso with cross-validation.
 reg_lasso = LassoCV(cv=10).fit(scale_X, scale_y)
 ```
 
-Let's display the results so we can see for which value of $$\alpha$$ the lowest mean squared error occurred. Note that sklearn uses the convention that $\alpha$ (rather than $$\lambda$$) is the shrinkage parameter.
+Let's display the results so we can see for which value of $$\alpha$$ the lowest mean squared error occurred. Note that sklearn uses the convention that $$\alpha$$ (rather than $$\lambda$$) is the shrinkage parameter.
 
 
 ```python?example=penreg

--- a/Model_Estimation/Matching/entropy_balancing.md
+++ b/Model_Estimation/Matching/entropy_balancing.md
@@ -17,7 +17,7 @@ $$\sum_{i|D_i=0}w_iA_i = \sum_{i|D_i=1}A_i$$
 
 where $$D_i$$ indicates treatment status and $$w_i$$ are the matching weights, and similarly for other variables for which the mean should match. However, other conditions can also be included, such as matching to equalize the variance of a matching variable, or the skewness, and so on. This is sort of like the [Generalized Method of Moments]({{ "/Model_Estimation/GLS/gmm.html" | relative_url }})
 
-Then, the entropy balancing algorithm searches for a set of matching weights $w_i$ that best satisfies the set of balance conditions. These matching weights can then be used to weight an analysis comparing the treated and control groups to remove measured confounding between them.
+Then, the entropy balancing algorithm searches for a set of matching weights $$w_i$$ that best satisfies the set of balance conditions. These matching weights can then be used to weight an analysis comparing the treated and control groups to remove measured confounding between them.
 
 ## Keep in Mind
 

--- a/Model_Estimation/Matching/propensity_score_matching.md
+++ b/Model_Estimation/Matching/propensity_score_matching.md
@@ -31,7 +31,7 @@ The recommendation of the current literature, by [King and Nielsen 2019](https:/
 * Exact matching
 * Stratification matching
 
-In this example we will focus on nearest neighor matching.
+In this example we will focus on nearest neighbor matching.
 
 ## Checking Balance
 
@@ -50,7 +50,7 @@ $$Y_i(1),Y_i(0)\bot|X_i$$
 
 - Propensity Score Matching also requires us to make the Common Support or Overlap Assumption: 
 
-$$0<Pr(D_i = 1 | Xi = x)<1$$
+$$0<Pr(D_i = 1 | X_i = x)<1$$
 
 The overlap assumption says that the probability that the treatment is equal to 1 for each level of x is between zero and one, or in other words there are both treated and untreated units for each level of x. 
 

--- a/Model_Estimation/Multilevel_Models/linear_mixed_effects_regression.md
+++ b/Model_Estimation/Multilevel_Models/linear_mixed_effects_regression.md
@@ -17,7 +17,7 @@ $$
 y_{ij} = \beta_{0j} + \beta_{1j}X_{1ij} + \beta_{2}X_{2ij} + e_{ij}
 $$
 
-The intercept $$\beta_{0j}$$ has a $j$ subscript and is allowed to vary over the sample at the $$j$$ level, where $$j$$ may indicate individual or group, depending on context. The slope on $$X_{1ij}$$, $$\beta_{1j}$$, is similarly allowed to vary over the sample. These are random effects. $$\beta_{2}$$ is not allowed to vary over the sample and so is fixed.
+The intercept $$\beta_{0j}$$ has a $$j$$ subscript and is allowed to vary over the sample at the $$j$$ level, where $$j$$ may indicate individual or group, depending on context. The slope on $$X_{1ij}$$, $$\beta_{1j}$$, is similarly allowed to vary over the sample. These are random effects. $$\beta_{2}$$ is not allowed to vary over the sample and so is fixed.
 
 The random parameters have their own "level-two" equations, which may or may not include level-two covariates. 
 

--- a/Model_Estimation/OLS/interaction_terms_and_polynomials.md
+++ b/Model_Estimation/OLS/interaction_terms_and_polynomials.md
@@ -128,7 +128,7 @@ Say that you want to estimate the model:
 
 $$ y = a_0 + a_1 * x + a_2 * 1/x + e $$ 
 
-and you want to estimate the marginal effects with respect to $x$. You can do this as follows:
+and you want to estimate the marginal effects with respect to $$x$$. You can do this as follows:
 
 ```stata
 * requires package f_able

--- a/Model_Estimation/Research_Design/synthetic_control_method.md
+++ b/Model_Estimation/Research_Design/synthetic_control_method.md
@@ -55,7 +55,7 @@ As a last bit of intuition, below is a graph depicting the upshot of the method.
 
 ## R
 
-To implement the synthetic control method in R, we will be using the package [Synth](https://cran.r-project.org/web/packages/Synth/Synth.pdf). While not used here, the **SynthTools** package also has a number of functions for making it easier to work with the **Synth** package. As stated above, the key part of the synthetic control method is to estimate the weight matrix $$W*$$ in order to form accurate estimates of the treatment unit. The Synth package provides you with the tools to find the weight matrix. From there, you can construct the synthetic control by interacting the $$W*$$ and the $Y$ values from the donor pool.
+To implement the synthetic control method in R, we will be using the package [Synth](https://cran.r-project.org/web/packages/Synth/Synth.pdf). While not used here, the **SynthTools** package also has a number of functions for making it easier to work with the **Synth** package. As stated above, the key part of the synthetic control method is to estimate the weight matrix $$W*$$ in order to form accurate estimates of the treatment unit. The Synth package provides you with the tools to find the weight matrix. From there, you can construct the synthetic control by interacting the $$W*$$ and the $$Y$$ values from the donor pool.
 
 ```r
 # First we will load Synth and dplyr.

--- a/Model_Estimation/Statistical_Inference/Marginal_Effects_in_Nonlinear_Regression.md
+++ b/Model_Estimation/Statistical_Inference/Marginal_Effects_in_Nonlinear_Regression.md
@@ -11,7 +11,7 @@ mathjax: true ## Switch to false if this page has no equations or other math ren
 
 In [linear regression]({{ "/Model_Estimation/OLS/simple_linear_regression.html" | relative_url }}), the effect of a predictor can be interpreted directly in terms of the outcome variable. For example, in the model $$Y = \beta_0 + \beta_1X + \varepsilon$$, a one-unit increase in $$X$$ is associated with a $$\beta$$-unit change in $$Y$$.
 
-However, in nonlinear regression, this is no longer the case. For example, if $$Y$$ is binary and $$E(Y=1) = F(\beta_0 + \beta_1X)$$ is estimated using a [logit regression]({{ "/Model_Estimation/GLS/logit_model.html" | relative_url }}) as a generalized linear model, then a one-unit increase in $$X$$ is associated with a $$\beta$$-unit change in the *index function* which then passes through the logit link function to produce a change in $E(Y=1)$. Confusing!
+However, in nonlinear regression, this is no longer the case. For example, if $$Y$$ is binary and $$E(Y=1) = F(\beta_0 + \beta_1X)$$ is estimated using a [logit regression]({{ "/Model_Estimation/GLS/logit_model.html" | relative_url }}) as a generalized linear model, then a one-unit increase in $$X$$ is associated with a $$\beta$$-unit change in the *index function* which then passes through the logit link function to produce a change in $$E(Y=1)$$. Confusing!
 
 Commonly, we would prefer to state our results in terms of changes in the actual dependent variable, which can be more intuitive. Marginal effects are one way of doing this. The *marginal effect* of $$X$$ on $$Y$$ in that logit regression is the relationship between a one-unit change in $$X$$ and the probability that $$Y=1$$. 
 

--- a/Model_Estimation/Statistical_Inference/nonlinear_hypothesis_tests.md
+++ b/Model_Estimation/Statistical_Inference/nonlinear_hypothesis_tests.md
@@ -13,7 +13,7 @@ Most regression output, or output from other methods that produce multiple coeff
 
 $$ Y = \beta_0 + \beta_1X + \beta_2Z + \varepsilon $$
 
-You may be interested in the ratio of the two effects, $\beta_1/\beta_2$, and would want an estimate of that combination, along with a standard error, and a hypothesis test comparing that estimate to 0 or some other value.
+You may be interested in the ratio of the two effects, $$\beta_1/\beta_2$$, and would want an estimate of that combination, along with a standard error, and a hypothesis test comparing that estimate to 0 or some other value.
 
 Estimates and tests of nonlinear combinations of coefficients are different than for linear combinations, because they imply restrictions on estimation that cannot be expressed in the form of a matrix of linear restrictions. The most common approach to producing a sampling distribution for a nonlinear combination of coefficients is the [delta method](https://en.wikipedia.org/wiki/Delta_method) and that is what all the commands on this page use.
 


### PR DESCRIPTION
Thank you for the great resource!

This pull request fixes
- several missing inline math modes,
- one missing subscript `Xi` to `X_i`,
- one spelling `neighor` to `neighbor`.